### PR TITLE
SQUASH: power: Fix up derped charging drivers

### DIFF
--- a/drivers/power/Kconfig
+++ b/drivers/power/Kconfig
@@ -545,7 +545,7 @@ config BATTERY_BQ28400
 config QPNP_CHARGER
 	tristate "QPNP Charger driver"
 	depends on SPMI || MSM_SPMI
- 	depends on OF_SPMI
+	depends on OF_SPMI
 	depends on THERMAL_QPNP_ADC_TM
 	help
 	  Say Y here to enable the switch mode battery charger
@@ -699,6 +699,22 @@ config DISABLE_TEMP_PROTECT
 	help
 	  Say Y here to enable a function which disabled TEMP protect...
 	  WARNNING:Only SCM could open it.
+
+config QUICK_CHARGE
+       bool "Enable Quick Charge v1.0, developed by Shoaib0597."
+       depends on SMB358_CHARGER
+       default y
+       help
+         This Fast-Charge Driver improves upon the ThunderCharge Current Control
+	 Driver. In ThunderCharge, a Constant Current (mA) is Forced at all times
+	 irrespective of the Battery State. This has Two Drawbacks. Firstly, the 
+	 Battery may get Damaged and secondly, users aren't able to Use Higher
+	 Current (mA) due to the Fear of Damage to Hardware. Now, this Quick Charge
+	 Driver fixes these issues. In this Driver, the Battery is Charged from 0%
+	 to 60% on Max. Current (mA), then from 61% to 90% on a Medium Current
+	 (mA) and finally from 91% to 100% on the Standard Current (mA) i.e.,
+	 1A. This Driver is Based on the Idea of Qualcomm's Quick Charge Technology
+	 and is Developed by Shoaib Anwar a.k.a. Shoaib0597.
 
 source "drivers/power/reset/Kconfig"
 

--- a/drivers/power/Makefile
+++ b/drivers/power/Makefile
@@ -66,6 +66,7 @@ obj-$(CONFIG_SMB135X_CHARGER)   += smb135x-charger.o
 obj-$(CONFIG_SMB1360_CHARGER_FG) += smb1360-charger-fg.o
 obj-$(CONFIG_SMB138X_CHARGER)	+= smb138x-charger.o pmic-voter.o
 obj-$(CONFIG_SMB358_CHARGER)	+= smb358-charger.o
+obj-$(CONFIG_QUICK_CHARGE)     	+= Quick_Charge.o
 obj-$(CONFIG_BATTERY_CW2015)	+= cw2015_battery.o ### add for c3
 obj-$(CONFIG_CHARGER_BQ2560) += bq2560x_charger.o
 obj-$(CONFIG_GAUGE_BQ27426) += bq27426_fg.o

--- a/drivers/power/Quick_Charge.c
+++ b/drivers/power/Quick_Charge.c
@@ -1,0 +1,113 @@
+/* Quick Charge v1.0, a Fast-Charge Driver Based on the Idea of Qualcomm's
+ * Quick-Charge Technology.
+ *
+ * For this Driver to Work properly, a Wall-Charger Capable of Supplying
+ * 1.5A Output is Required.
+ *
+ * Copyright (c) 2017, Shoaib Anwar <Shoaib0595@gmail.com>.
+ *
+ * Based on ThunderCharge Current Control, by Varun Chitre <varun.chitre15@gmail.com>.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ */
+
+#include <linux/module.h>
+#include <linux/Quick_Charge.h>
+
+#define ENABLED			1
+#define QUICK_CHARGE		"Quick_Charge"
+#define CURRENT			1800
+
+int QC_Toggle = ENABLED;
+int Dynamic_Current = CURRENT;
+
+static ssize_t qc_toggle_show(struct kobject *kobj, struct kobj_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%d", QC_Toggle);
+}
+
+static ssize_t qc_toggle_store(struct kobject *kobj, struct kobj_attribute *attr, const char *buf, size_t count)
+{
+	int val;
+	sscanf (buf, "%d", &val);
+	switch (val)
+	{
+	case 0:
+	case 1:
+		QC_Toggle = val;
+	break;
+	default:
+		pr_info("%s: Invalid Value", QUICK_CHARGE);
+    	break;
+	}
+return count;
+}
+
+static ssize_t dynamic_current_show(struct kobject *kobj, struct kobj_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%d", Dynamic_Current);
+}
+
+static struct kobj_attribute qc_toggle_attribute =
+	__ATTR(QC_Toggle,
+		0660,
+		qc_toggle_show,
+		qc_toggle_store);
+
+static struct kobj_attribute dynamic_current_attribute =
+	__ATTR(Dynamic_Current,
+		0444,
+		dynamic_current_show,
+		NULL);
+
+static struct attribute *charger_control_attrs[] =
+	{
+		&qc_toggle_attribute.attr,
+		&dynamic_current_attribute.attr,
+		NULL,
+	};
+
+static struct attribute_group chgr_control_attr_group =
+	{
+		.attrs = charger_control_attrs,
+	};
+
+static struct kobject *charger_control_kobj;
+
+static int charger_control_probe(void)
+{
+	int sysfs_result;
+	printk(KERN_DEBUG "[%s]\n",__func__);
+
+	charger_control_kobj = kobject_create_and_add("Quick_Charge", kernel_kobj);
+
+	if (!charger_control_kobj)
+	{
+	   pr_err("%s Interface create failed!\n", __FUNCTION__);
+	   return -ENOMEM;
+        }
+
+	sysfs_result = sysfs_create_group(charger_control_kobj, &chgr_control_attr_group);
+
+	if (sysfs_result)
+	{
+	   pr_info("%s sysfs create failed!\n", __FUNCTION__);
+	   kobject_put(charger_control_kobj);
+	}
+	return sysfs_result;
+}
+
+static void charger_control_remove(void)
+{
+	if (charger_control_kobj != NULL)
+	   kobject_put(charger_control_kobj);
+}
+
+module_init(charger_control_probe);
+module_exit(charger_control_remove);
+MODULE_LICENSE("GPL and Additional Rights");
+MODULE_AUTHOR("Shoaib Anwar <Shoaib0595@gmail.com>");
+MODULE_DESCRIPTION("Quick Charge v1.0");

--- a/drivers/power/smb358-charger.c
+++ b/drivers/power/smb358-charger.c
@@ -199,6 +199,9 @@
 #define BATTERY_FCC 3000
 #endif
 
+#ifdef CONFIG_QUICK_CHARGE
+#include <linux/Quick_Charge.h>
+#endif
 
 int pre_usb_current_ma = -EINVAL;
 bool thermal = false;
@@ -1241,7 +1244,7 @@ static int get_prop_current_now(struct smb358_charger *chip)
 		} else {
 			pr_debug("No BMS supply registered return 0\n");
 		}
-	return 1000;
+	return 1500;
 }
 
 static int smb358_get_prop_charge_type(struct smb358_charger *chip)
@@ -2476,7 +2479,36 @@ static void smb358_external_power_changed(struct power_supply *psy)
 		dev_err(chip->dev,
 			"Couldn't read USB current_max property, rc=%d\n", rc);
 	else
-		current_limit = prop.intval / 1000;
+        #ifdef CONFIG_QUICK_CHARGE
+        {
+           if (!((prop.intval / 1000) == 0))
+           {
+	      if (QC_Toggle == 1) 
+	      {
+		 // If Current (mA) is Equal to 500 mA, then USB is Connected.
+                 if ((prop.intval / 1000) == 500) 
+		 {
+		    // Raise USB-Charging Current (mA) to 1000 mA (Maximum Supported).
+                    pr_info("Using Custom USB Current (mA) %d", 1000);
+                    current_limit = 1000;
+                 }
+                 else 
+	         {
+                     pr_info("Using Quick Charge Current (mA) %d", Dynamic_Current);
+                     current_limit = Dynamic_Current;
+                 }
+              }
+              else
+		  // If Quick Charge is Disabled, Restore Default Value of Current (mA). 
+                  current_limit = prop.intval / 1000;
+           }
+	   else
+	       current_limit = 0;
+	}
+	#else
+	    // If Quick Charge is Not Compiled, Leave Current (mA) Value Untouched.
+	    current_limit = prop.intval / 1000;
+	#endif
 
 	chip->psy_usb_ma = current_limit;
 	smb358_enable_volatile_writes(chip);
@@ -2775,10 +2807,25 @@ static int smb_parse_dt(struct smb358_charger *chip)
 	else
 		chip->chg_valid_act_low = gpio_flags & OF_GPIO_ACTIVE_LOW;
 
+        #ifdef CONFIG_QUICK_CHARGE
+	// If Quick Charge is Enabled, then Set the Max. Current to the Value of Dynamic Current of the Driver.
+	if (QC_Toggle == 1)
+	   chip->fastchg_current_max_ma = Dynamic_Current;
+	else
+	{
+	// If Quick Charge is Disabled, then Restore the Max. Current Value to the Default as Specified in DTB.
 	rc = of_property_read_u32(node, "qcom,fastchg-current-max-ma",
 						&chip->fastchg_current_max_ma);
 	if (rc)
 		chip->fastchg_current_max_ma = SMB358_FAST_CHG_MAX_MA;
+	}
+        #else
+	// If Quick Charge is not Compiled, then Read the Default Value only
+	rc = of_property_read_u32(node, "qcom,fastchg-current-max-ma",
+						&chip->fastchg_current_max_ma);
+	if (rc)
+		chip->fastchg_current_max_ma = SMB358_FAST_CHG_MAX_MA;
+        #endif
 
 	chip->iterm_disabled = of_property_read_bool(node,
 					"qcom,iterm-disabled");

--- a/include/linux/Quick_Charge.h
+++ b/include/linux/Quick_Charge.h
@@ -1,0 +1,17 @@
+/* Header File for Quick Charge v1.0 Driver.
+ *
+ * Copyright (c) 2017, Shoaib Anwar <Shoaib0595@gmail.com>.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ */
+
+#ifndef __LINUX_QUICK_CHARGE_H
+#define __LINUX_QUICK_CHARGE_H
+
+extern int QC_Toggle;
+extern int Dynamic_Current;
+
+#endif


### PR DESCRIPTION
* Added Quick Charge drivers
* corrected quick charge implement in SMB358 for Rolex.
* added power input statement for fix up ghost charging issue for Rolex.
* I've edited max current limit of Quick Charge to 1.8mA
* but mostly xiaomi phone shiped with 1.5mA output current
* so, in this changes will re-write max current prop on Pie roms to 1.5mA.

Signed-off-by: najahiiii <tlogitechnjhi@gmail.com>